### PR TITLE
Overridable CropFaces source image

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -110,6 +110,9 @@ class CropFaces:
                 'crop_size': ('INT', {'default': 512, 'min': 512, 'max': 1024, 'step': 128}),
                 'crop_factor': ('FLOAT', {'default': 1.5, 'min': 1.0, 'max': 3, 'step': 0.1}),
                 'mask_type': (mask_types,)
+            },
+            'optional': {
+                'image_override': ('IMAGE',),
             }
         }
     
@@ -118,7 +121,7 @@ class CropFaces:
     FUNCTION = 'run'
     CATEGORY = 'facetools'
 
-    def run(self, faces, crop_size, crop_factor, mask_type):
+    def run(self, faces, crop_size, crop_factor, mask_type, image_override=None):
         if len(faces) == 0:
             empty_crop = torch.zeros((1,512,512,3))
             empty_mask = torch.zeros((1,512,512))
@@ -132,7 +135,7 @@ class CropFaces:
         masks = []
         warps = []
         for face in faces:
-            M, crop = face.crop(crop_size, crop_factor)
+            M, crop = face.crop(crop_size, crop_factor, image_override)
             mask = mask_crop(face, M, crop, mask_type)
             crops.append(np.array(crop[0]))
             masks.append(np.array(mask[0]))

--- a/utils.py
+++ b/utils.py
@@ -109,7 +109,7 @@ class Face:
         rot = cv2.getRotationMatrix2D((128*s,128*s), 90*i, 1)
         self.R = np.vstack((rot, np.array((0,0,1))))
     
-    def crop(self, size, crop_factor):
+    def crop(self, size, crop_factor, image_override=None):
         S = np.array([[1/crop_factor, 0, 0], [0, 1/crop_factor, 0], [0, 0, 1]])
         M = estimate_norm(self.kps, size)
         N = M @ self.R @ self.T2
@@ -117,7 +117,8 @@ class Face:
         T3 = np.array([[1, 0, -cx], [0, 1, -cy], [0, 0, 1]])
         T4 = np.array([[1, 0, cx], [0, 1, cy], [0, 0, 1]])
         N = N @ T4 @ S @ T3
-        crop = cv2.warpAffine(self.img.numpy(), N, (size, size))
+        img = self.img if image_override is None else image_override.squeeze()
+        crop = cv2.warpAffine(img.numpy(), N, (size, size))
         crop = torch.from_numpy(crop)[None]
         
         return N, crop


### PR DESCRIPTION
It allows detecting the faces only once, and use the same bounding boxes on another image where there are faces in the same position.

This could be useful with eg. InstantID face transfering from a source image to a target where the number of faces and their batch position on both images must match.
- the source image face cutouts can be provided to InstantID as source images
- the cutouts done on the destination image can be provided to InstantId as image_kps landmark reference and KSampler latent input and then apply the results with WarpFacesBack to the destination image.

An improvement to this could be made however, as it will not enforce the new image to be the same size as the original, so the bounding boxes gets interpreted at wrong locations. You must manually scale them to same dimension (eg. I'm upscaling the source image to the target image's size with a simple latent upscale before doing face detection).